### PR TITLE
Fix build failed: error: ‘FILE’ does not name a type

### DIFF
--- a/plugins/filter_poisson/src/Geometry.h
+++ b/plugins/filter_poisson/src/Geometry.h
@@ -31,6 +31,7 @@ DAMAGE.
 #include <math.h>
 #include <vector>
 #include <unordered_map>
+#include <bits/types/FILE.h>
 //#include "Hash.h"
 
 template<class Real>

--- a/plugins/filter_poisson/src/Geometry.h
+++ b/plugins/filter_poisson/src/Geometry.h
@@ -26,12 +26,16 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
 DAMAGE.
 */
 
+#pragma once
+#ifndef FILE_h
+#define FILE_h
+#include <bits/types/FILE.h>
+#endif // FILE.h
 #ifndef GEOMETRY_INCLUDED
 #define GEOMETRY_INCLUDED
 #include <math.h>
 #include <vector>
 #include <unordered_map>
-#include <bits/types/FILE.h>
 //#include "Hash.h"
 
 template<class Real>

--- a/plugins/filter_poisson/src/Geometry.h
+++ b/plugins/filter_poisson/src/Geometry.h
@@ -8,14 +8,14 @@ are permitted provided that the following conditions are met:
 Redistributions of source code must retain the above copyright notice, this list of
 conditions and the following disclaimer. Redistributions in binary form must reproduce
 the above copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the distribution. 
+in the documentation and/or other materials provided with the distribution.
 
 Neither the name of the Johns Hopkins University nor the names of its contributors
 may be used to endorse or promote products derived from this software without specific
-prior written permission. 
+prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES
 OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
 SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
@@ -26,13 +26,11 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
 DAMAGE.
 */
 
-#pragma once
-#ifndef FILE_h
-#define FILE_h
-#include <bits/types/FILE.h>
-#endif // FILE.h
 #ifndef GEOMETRY_INCLUDED
 #define GEOMETRY_INCLUDED
+#ifdef __linux__
+#include <bits/types/FILE.h>
+#endif //__linux__
 #include <math.h>
 #include <vector>
 #include <unordered_map>
@@ -99,7 +97,7 @@ public:
 		}
 		return Area()/d;
 	}
-	
+
 };
 class CoredPointIndex{
 public:


### PR DESCRIPTION
Fix build failed: error: ‘FILE’ does not name a type

https://github.com/flathub/net.meshlab.MeshLab/issues/6